### PR TITLE
Added the option to set a fixed window size

### DIFF
--- a/ConsoleHandler.cs
+++ b/ConsoleHandler.cs
@@ -15,8 +15,16 @@ namespace ML.ConstantConsolePos {
       rect = consoleRect;
     }
 
-    public void SetRect(in WinAPI.RECT rect) {
-      WinAPI.SetWindowPos(_consoleHandle, IntPtr.Zero, rect.Left, rect.Top, rect.Width, rect.Height, WinAPI.SWP_NOZORDER | WinAPI.SWP_SHOWWINDOW);
+    public WinAPI.RECT GetRect() {
+      WinAPI.GetWindowRect(_consoleHandle, out var rect);
+      return rect;
+    }
+
+    public void SetRect(Settings settings) {
+      var rect = settings.ConsoleRect;
+      var height = settings.UseFixedSize.Value ? settings.FixedHeight.Value : rect.Height;
+      var width = settings.UseFixedSize.Value ? settings.FixedWidth.Value : rect.Width;
+      WinAPI.SetWindowPos(_consoleHandle, IntPtr.Zero, rect.Left, rect.Top, width, height, WinAPI.SWP_NOZORDER | WinAPI.SWP_SHOWWINDOW);
     }
   }
 }

--- a/PluginMain.cs
+++ b/PluginMain.cs
@@ -10,8 +10,8 @@ namespace ML.ConstantConsolePos {
     WinAPI.RECT _consoleRect;
 
     public override void OnPreInitialization() {
-      _settings = new Settings();
       _console = new ConsoleHandler();
+      _settings = new Settings(_console);
 
       if(!_console.IsPresent)
         return;
@@ -22,7 +22,7 @@ namespace ML.ConstantConsolePos {
         _settings.ConsoleRect = rect;
         _consoleRect = rect;
       } else {
-        _console.SetRect(_settings.ConsoleRect);
+        _console.SetRect(_settings);
         _consoleRect = _settings.ConsoleRect;
       }
     }

--- a/Settings.cs
+++ b/Settings.cs
@@ -6,6 +6,10 @@ namespace ML.ConstantConsolePos {
     MelonPreferences_Entry<WinAPI.RECT> _consoleRect;
     MelonPreferences_Entry<float> _checkPositionEverySeconds;
 
+    internal readonly MelonPreferences_Entry<bool> UseFixedSize;
+    internal readonly MelonPreferences_Entry<int> FixedHeight;
+    internal readonly MelonPreferences_Entry<int> FixedWidth;
+
     public WinAPI.RECT ConsoleRect {
       get {
         return _consoleRect.Value;
@@ -26,10 +30,16 @@ namespace ML.ConstantConsolePos {
       }
     }
 
-    public Settings() {
+
+
+    public Settings(ConsoleHandler console) {
       _category = MelonPreferences.CreateCategory("ML_ConstantConsolePos");
       _consoleRect = _category.CreateEntry("ConsoleRect", WinAPI.RECT.Zero);
       _checkPositionEverySeconds = _category.CreateEntry("CheckPositionEverySeconds", 1.0f);
+
+      UseFixedSize = _category.CreateEntry("UseFixedWindowSize", false);
+      FixedHeight = _category.CreateEntry("FixedHeight", console.GetRect().Height);
+      FixedWidth = _category.CreateEntry("FixedWidth", console.GetRect().Width);
     }
 
     public void Save() {


### PR DESCRIPTION
Heya, I was having the https://github.com/yamiM0NSTER/ML.ConstantConsolePos/issues/1 issue so I decided to attempt a fix, that WinAPI is something else... All I wanted to do was getting the current screen resolution but I gave up after a few attempts ;_;

The issue is that since my monitors are different resolutions, so the rect coords will depend on the monitor size, so every time I would start the game the SetRect would be called with bigger and bigger sizes (since it saves the coords from the higher res monitor, but the set starts on the lower res monitor).

I ended up by giving up on the WinAPI way and doing an easy solution (optional setting for fixed width/height). This way I can control the exact size I want the window to be.

Not sure if you want to add this to your branch. As it's only an issue for people with different resolution monitors (and it's not a clean solution).